### PR TITLE
Fixed the authority spelling

### DIFF
--- a/MyNotes/app/build.gradle
+++ b/MyNotes/app/build.gradle
@@ -16,7 +16,7 @@ android {
     compileSdkVersion 25
     buildToolsVersion "25.0.3"
     defaultConfig {
-        applicationId "com.shellmonger.notes"
+        applicationId "com.amazonaws.mobile.samples.notes"
         minSdkVersion 19
         targetSdkVersion 25
         versionCode 1

--- a/MyNotes/app/src/main/java/com/amazonaws/mobile/samples/mynotes/data/NotesContentContract.java
+++ b/MyNotes/app/src/main/java/com/amazonaws/mobile/samples/mynotes/data/NotesContentContract.java
@@ -99,13 +99,13 @@ public class NotesContentContract {
          * The mime type of a directory of items
          */
         public static final String CONTENT_DIR_TYPE =
-                ContentResolver.CURSOR_DIR_BASE_TYPE + "/vnd.com.shellmonger.notes";
+                ContentResolver.CURSOR_DIR_BASE_TYPE + "/vnd.com.amazonaws.mobile.samples.notes";
 
         /**
          * The mime type of a single item
          */
         public static final String CONTENT_ITEM_TYPE =
-                ContentResolver.CURSOR_ITEM_BASE_TYPE + "/vnd.com.shellmonger.notes";
+                ContentResolver.CURSOR_ITEM_BASE_TYPE + "/vnd.com.amazonaws.mobile.samples.notes";
 
         /**
          * A projection of all columns in the items table


### PR DESCRIPTION
The authorities within the NotesContentContractor were wrong - correcting them.